### PR TITLE
Fixing bug Undefined offset: 0

### DIFF
--- a/src/Roumen/Disqus/disqusapi/disqusapi.php
+++ b/src/Roumen/Disqus/disqusapi/disqusapi.php
@@ -94,7 +94,7 @@ class DisqusResource {
         if (!$resource) {
             throw new DisqusInterfaceNotDefined();
         }
-        $kwargs = (array)$args[0];
+        $kwargs = ((array)$args) ? (array)$args[0] : false;
 
         foreach ((array)$resource->required as $k) {
             if (empty($kwargs[$k])) {


### PR DESCRIPTION
When using your package like this for example: 
$disqus->users->listForums()
We get an error of "Undefined offset: 0" that because your $kwargs want the first element of the array $args. But in this case, the args is null and throw and error.
I've added a test to check if the args is null or not before casting.
Hope it's helps.